### PR TITLE
[WIP] Update twilight to >0.12

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-cache-inmemory"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8e2b587a21f10f5abe021d7f737642ea7667be99d3a03bdf6e57187a4f9f03"
+checksum = "7cd4d58a61cbd17bb8ae13877434b3efd13b721c6800fccda889f810e39d9c72"
 dependencies = [
  "bitflags",
  "dashmap",
@@ -2411,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-gateway"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf9892830808d1a2847ebd2e842726979f292ccff67db8c988b6167ebc0427c"
+checksum = "2e03ce45fe4bbc172c472780d6c006d354c742d58403b2c4c28a9e065ff4e30c"
 dependencies = [
  "bitflags",
  "flate2",
@@ -2434,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-gateway-queue"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99db628118bca4789e98a928d60cf44bc67cca7d1ac5ea2ab22e65b6b0d640a7"
+checksum = "acbb9002e25edd2ffea0d5590554309e196a16c05564754bb28585a388eb320b"
 dependencies = [
  "tokio",
  "tracing",
@@ -2445,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-http"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f608fc399bf8c6961747d3030dbe73d78a3de2ee20f7dca9b8befb0dc40094"
+checksum = "a790c974895903d1f6dad5b7443412244ec5a3d0ac865b9f602164bb62485185"
 dependencies = [
  "brotli",
  "hyper",
@@ -2465,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-http-ratelimiting"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173ac00feb4dcf8f8005c8d304627790f4dfcbc0479ca9550fecb896616df253"
+checksum = "ae2f988cd4353156c58f8ea00332dd77b0b23c3857b78a06d9f02ad3edea14a8"
 dependencies = [
  "futures-util",
  "http",
@@ -2477,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-model"
-version = "0.11.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7475388ee4cd61769e19d5ae100b2fbafcf570f4e9647350546eebd679214b"
+checksum = "2e1ec8a45b12f757e67d1b427b4b0286f8c39126c986198f2d8cd6e9b13a98c7"
 dependencies = [
  "bitflags",
  "serde 1.0.142",
@@ -2491,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-util"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00a54f7f0d756fa4dd52fb08144a5cad7daad1a454b330ce6ab16bdbab750d8"
+checksum = "b70d18462269ead0abd8e66b7a1656911457af44d9a7f9873d8e7b64235a4227"
 dependencies = [
  "twilight-model",
  "twilight-validate",
@@ -2501,9 +2501,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-validate"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d6f675e4b2aecbe60105ef40d5d88e08f0c6f5c23d9a3f93a6e3ed82c810db"
+checksum = "e002f0075b0d8beb5971563a9beeb932256d6a5080ca07939bc505e3bf085161"
 dependencies = [
  "twilight-model",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 tokio = { version = "1.18.2", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0.137", features = ["derive"] }
 actix-web = "4.0.1"
-twilight-gateway = "0.11.0"
-twilight-http = "0.11.0"
-twilight-http-ratelimiting = "0.11.0"
-twilight-model = "0.11.0"
-twilight-cache-inmemory = { version = "0.11.0", features = ["permission-calculator"] }
-twilight-util = { version = "0.11.0", features = ["builder", "permission-calculator"] }
+twilight-gateway = "0.12"
+twilight-http = "0.12"
+twilight-http-ratelimiting = "0.12"
+twilight-model = "0.12"
+twilight-cache-inmemory = { version = "0.12", features = ["permission-calculator"] }
+twilight-util = { version = "0.12", features = ["builder", "permission-calculator"] }
 lazy_static = "1.4.0"
 rust-embed = { version = "6.4.0", optional = true }
 mime = "0.3.16"

--- a/backend/src/api/wire/guild.rs
+++ b/backend/src/api/wire/guild.rs
@@ -52,7 +52,7 @@ impl From<&Role> for GuildRoleWire {
 pub struct GuildChannelWire {
     pub id: Id<ChannelMarker>,
     pub name: Option<String>,
-    pub position: Option<i64>,
+    pub position: Option<i16>,
     pub parent_id: Option<String>,
     #[serde(rename = "type")]
     pub kind: ChannelType,

--- a/backend/src/bot/commands/embed.rs
+++ b/backend/src/bot/commands/embed.rs
@@ -32,7 +32,7 @@ pub fn command_definition() -> Command {
 pub async fn handle_command(
     http: InteractionClient<'_>,
     interaction: Interaction,
-    cmd: &CommandData,
+    _cmd: Box<CommandData>,
 ) -> InteractionResult {
     let user = interaction.member.unwrap().user.unwrap();
     let avatar_url = user_avatar_url(user.id, user.discriminator, user.avatar, true);
@@ -119,9 +119,9 @@ pub async fn handle_command(
 pub async fn handle_modal(
     http: InteractionClient<'_>,
     interaction: Interaction,
-    modal: &ModalInteractionData,
+    modal: ModalInteractionData,
 ) -> InteractionResult {
-    if !modal
+    if !interaction
         .member
         .unwrap()
         .permissions

--- a/backend/src/bot/commands/format.rs
+++ b/backend/src/bot/commands/format.rs
@@ -1,10 +1,8 @@
 use twilight_cache_inmemory::model::CachedEmoji;
 use twilight_http::client::InteractionClient;
 use twilight_model::application::command::{Command, CommandOptionChoice, CommandType};
-use twilight_model::application::interaction::application_command::CommandOptionValue;
-use twilight_model::application::interaction::{
-    ApplicationCommand, ApplicationCommandAutocomplete,
-};
+use twilight_model::application::interaction::application_command::{CommandData, CommandOptionValue};
+use twilight_model::application::interaction::Interaction;
 use twilight_model::http::interaction::{
     InteractionResponse, InteractionResponseData, InteractionResponseType,
 };
@@ -18,60 +16,58 @@ use crate::bot::DISCORD_CACHE;
 
 pub fn command_definition() -> Command {
     CommandBuilder::new(
-        "format".into(),
-        "Get the API format for mentions, channels, roles, & custom emojis".into(),
+        "format",
+        "Get the API format for mentions, channels, roles, & custom emojis",
         CommandType::ChatInput,
     )
     .option(
         SubCommandBuilder::new(
-            "text".into(),
-            "Get the API format for a text with multiple mentions, channels, & custom emojis"
-                .into(),
+            "text",
+            "Get the API format for a text with multiple mentions, channels, & custom emojis",
         )
         .option(
             StringBuilder::new(
-                "text".into(),
-                "The text that you want to format (usually containing mentions or custom emojis)"
-                    .into(),
+                "text",
+                "The text that you want to format (usually containing mentions or custom emojis)",
             )
             .required(true),
         ),
     )
     .option(
         SubCommandBuilder::new(
-            "user".into(),
-            "Get the API format for mentioning a user".into(),
+            "user",
+            "Get the API format for mentioning a user"
         )
         .option(
-            UserBuilder::new("target".into(), "The user you want to mention".into()).required(true),
+            UserBuilder::new("target", "The user you want to mention").required(true),
         ),
     )
     .option(
         SubCommandBuilder::new(
-            "channel".into(),
-            "Get the API format for mentioning a channel".into(),
+            "channel",
+            "Get the API format for mentioning a channel",
         )
         .option(
-            ChannelBuilder::new("target".into(), "The channel you want to mention".into())
+            ChannelBuilder::new("target", "The channel you want to mention")
                 .required(true),
         ),
     )
     .option(
         SubCommandBuilder::new(
-            "role".into(),
-            "Get the API format for mentioning a role".into(),
+            "role",
+            "Get the API format for mentioning a role",
         )
         .option(
-            RoleBuilder::new("target".into(), "The role you want to mention".into()).required(true),
+            RoleBuilder::new("target", "The role you want to mention").required(true),
         ),
     )
     .option(
         SubCommandBuilder::new(
-            "emoji".into(),
-            "Get the API format for a custom emoji".into(),
+            "emoji",
+            "Get the API format for a custom emoji",
         )
         .option(
-            StringBuilder::new("target".into(), "The custom emoji you want to use".into())
+            StringBuilder::new("target", "The custom emoji you want to use")
                 .autocomplete(true)
                 .required(true),
         ),
@@ -81,9 +77,10 @@ pub fn command_definition() -> Command {
 
 pub async fn handle_command(
     http: InteractionClient<'_>,
-    cmd: Box<ApplicationCommand>,
+    interaction: Interaction,
+    cmd: &CommandData,
 ) -> InteractionResult {
-    let sub_cmd = cmd.data.options.get(0).unwrap();
+    let sub_cmd = cmd.options.get(0).unwrap();
     let mut options = match &sub_cmd.value {
         CommandOptionValue::SubCommand(options) => options.clone(),
         _ => unreachable!(),
@@ -98,8 +95,8 @@ pub async fn handle_command(
 
             simple_response(
                 &http,
-                cmd.id,
-                &cmd.token,
+                interaction.id,
+                &interaction.token,
                 format!("API format for <@{0}>: ```<@{0}>```", user_id),
             )
             .await?;
@@ -112,8 +109,8 @@ pub async fn handle_command(
 
             simple_response(
                 &http,
-                cmd.id,
-                &cmd.token,
+                interaction.id,
+                &interaction.token,
                 format!("API format for <@&{0}>: ```<@&{0}>```", role_id),
             )
             .await?;
@@ -126,8 +123,8 @@ pub async fn handle_command(
 
             simple_response(
                 &http,
-                cmd.id,
-                &cmd.token,
+                interaction.id,
+                &interaction.token,
                 format!("API format for <#{0}>: ```<#{0}>```", channel_id),
             )
             .await?;
@@ -140,8 +137,8 @@ pub async fn handle_command(
 
             simple_response(
                 &http,
-                cmd.id,
-                &cmd.token,
+                interaction.id,
+                &interaction.token,
                 format!("API format for {0}: ```{0}```", value),
             )
             .await?;
@@ -154,8 +151,8 @@ pub async fn handle_command(
 
             simple_response(
                 &http,
-                cmd.id,
-                &cmd.token,
+                interaction.id,
+                &interaction.token,
                 format!("API format for the provided text: ```{0}```", value),
             )
             .await?;
@@ -169,7 +166,7 @@ pub async fn handle_autocomplete(
     http: InteractionClient<'_>,
     cmd: Box<ApplicationCommandAutocomplete>,
 ) -> InteractionResult {
-    let sub_cmd = cmd.data.options.get(0).unwrap();
+    let sub_cmd = cmd.options.get(0).unwrap();
     let search = match &sub_cmd.options.get(0).unwrap().value {
         Some(e) => e,
         _ => unreachable!(),

--- a/backend/src/bot/commands/format.rs
+++ b/backend/src/bot/commands/format.rs
@@ -1,7 +1,9 @@
 use twilight_cache_inmemory::model::CachedEmoji;
 use twilight_http::client::InteractionClient;
 use twilight_model::application::command::{Command, CommandOptionChoice, CommandType};
-use twilight_model::application::interaction::application_command::{CommandData, CommandOptionValue};
+use twilight_model::application::interaction::application_command::{
+    CommandData, CommandOptionValue,
+};
 use twilight_model::application::interaction::Interaction;
 use twilight_model::http::interaction::{
     InteractionResponse, InteractionResponseData, InteractionResponseType,
@@ -10,9 +12,9 @@ use twilight_util::builder::command::{
     ChannelBuilder, CommandBuilder, RoleBuilder, StringBuilder, SubCommandBuilder, UserBuilder,
 };
 
-use crate::bot::commands::{InteractionResult, simple_response};
-use crate::bot::DISCORD_CACHE;
+use crate::bot::commands::{simple_response, InteractionResult};
 use crate::bot::emojis::EMOJIS;
+use crate::bot::DISCORD_CACHE;
 
 pub fn command_definition() -> Command {
     CommandBuilder::new(
@@ -34,39 +36,20 @@ pub fn command_definition() -> Command {
         ),
     )
     .option(
-        SubCommandBuilder::new(
-            "user",
-            "Get the API format for mentioning a user"
-        )
-        .option(
-            UserBuilder::new("target", "The user you want to mention").required(true),
+        SubCommandBuilder::new("user", "Get the API format for mentioning a user")
+            .option(UserBuilder::new("target", "The user you want to mention").required(true)),
+    )
+    .option(
+        SubCommandBuilder::new("channel", "Get the API format for mentioning a channel").option(
+            ChannelBuilder::new("target", "The channel you want to mention").required(true),
         ),
     )
     .option(
-        SubCommandBuilder::new(
-            "channel",
-            "Get the API format for mentioning a channel",
-        )
-        .option(
-            ChannelBuilder::new("target", "The channel you want to mention")
-                .required(true),
-        ),
+        SubCommandBuilder::new("role", "Get the API format for mentioning a role")
+            .option(RoleBuilder::new("target", "The role you want to mention").required(true)),
     )
     .option(
-        SubCommandBuilder::new(
-            "role",
-            "Get the API format for mentioning a role",
-        )
-        .option(
-            RoleBuilder::new("target", "The role you want to mention").required(true),
-        ),
-    )
-    .option(
-        SubCommandBuilder::new(
-            "emoji",
-            "Get the API format for a custom emoji",
-        )
-        .option(
+        SubCommandBuilder::new("emoji", "Get the API format for a custom emoji").option(
             StringBuilder::new("target", "The custom emoji you want to use")
                 .autocomplete(true)
                 .required(true),
@@ -142,7 +125,7 @@ pub async fn handle_command(
                 format!("API format for {0}: ```{0}```", value),
             )
             .await?;
-        },
+        }
         "text" => {
             let value = match options.pop().unwrap().value {
                 CommandOptionValue::String(e) => e,
@@ -171,8 +154,9 @@ pub async fn handle_autocomplete(
         CommandOptionValue::SubCommand(options) => options.clone(),
         _ => unreachable!(),
     };
+    println!("{:?}", options);
     let search = match &options.get(0).unwrap().value {
-        CommandOptionValue::String(e) => e,
+        CommandOptionValue::Focused(e, _) => e,
         _ => unreachable!(),
     };
 

--- a/backend/src/bot/commands/help.rs
+++ b/backend/src/bot/commands/help.rs
@@ -1,14 +1,15 @@
 use twilight_http::client::InteractionClient;
 use twilight_model::application::command::{Command, CommandType};
-use twilight_model::application::interaction::ApplicationCommand;
+use twilight_model::application::interaction::application_command::CommandData;
+use twilight_model::application::interaction::Interaction;
 use twilight_util::builder::command::CommandBuilder;
 
 use crate::bot::commands::{simple_response, InteractionResult};
 
 pub fn command_definition() -> Command {
     CommandBuilder::new(
-        "help".into(),
-        "Join our Discord Server to get support".into(),
+        "help",
+        "Join our Discord Server to get support",
         CommandType::ChatInput,
     )
     .build()
@@ -16,12 +17,13 @@ pub fn command_definition() -> Command {
 
 pub async fn handle_command(
     http: InteractionClient<'_>,
-    cmd: Box<ApplicationCommand>,
+    interaction: Interaction,
+    _cmd: &CommandData,
 ) -> InteractionResult {
     simple_response(
         &http,
-        cmd.id,
-        &cmd.token,
+        interaction.id,
+        &interaction.token,
         "You can join our Discord Server with the following link: <https://discord.club/discord>"
             .into(),
     )

--- a/backend/src/bot/commands/help.rs
+++ b/backend/src/bot/commands/help.rs
@@ -18,7 +18,7 @@ pub fn command_definition() -> Command {
 pub async fn handle_command(
     http: InteractionClient<'_>,
     interaction: Interaction,
-    _cmd: &CommandData,
+    _cmd: Box<CommandData>,
 ) -> InteractionResult {
     simple_response(
         &http,

--- a/backend/src/bot/commands/image.rs
+++ b/backend/src/bot/commands/image.rs
@@ -221,7 +221,7 @@ pub async fn handle_autocomplete(
         _ => unreachable!(),
     };
     let search = match &options.get(0).unwrap().value {
-        CommandOptionValue::String(e) => e,
+        CommandOptionValue::Focused(e, _) => e,
         _ => unreachable!(),
     };
 

--- a/backend/src/bot/commands/invite.rs
+++ b/backend/src/bot/commands/invite.rs
@@ -1,14 +1,15 @@
 use twilight_http::client::InteractionClient;
 use twilight_model::application::command::{Command, CommandType};
-use twilight_model::application::interaction::ApplicationCommand;
+use twilight_model::application::interaction::application_command::CommandData;
+use twilight_model::application::interaction::Interaction;
 use twilight_util::builder::command::CommandBuilder;
 
 use crate::bot::commands::{simple_response, InteractionResult};
 
 pub fn command_definition() -> Command {
     CommandBuilder::new(
-        "invite".into(),
-        "Invite Embed Generator to your server".into(),
+        "invite",
+        "Invite Embed Generator to your server",
         CommandType::ChatInput,
     )
     .build()
@@ -16,12 +17,13 @@ pub fn command_definition() -> Command {
 
 pub async fn handle_command(
     http: InteractionClient<'_>,
-    cmd: Box<ApplicationCommand>,
+    interaction: Interaction,
+    _cmd: &CommandData,
 ) -> InteractionResult {
     simple_response(
         &http,
-        cmd.id,
-        &cmd.token,
+        interaction.id,
+        &interaction.token,
         "You can invite Embed Generator with the following link: <https://discord.club/invite>"
             .into(),
     )

--- a/backend/src/bot/commands/invite.rs
+++ b/backend/src/bot/commands/invite.rs
@@ -18,7 +18,7 @@ pub fn command_definition() -> Command {
 pub async fn handle_command(
     http: InteractionClient<'_>,
     interaction: Interaction,
-    _cmd: &CommandData,
+    _cmd: Box<CommandData>,
 ) -> InteractionResult {
     simple_response(
         &http,

--- a/backend/src/bot/commands/message.rs
+++ b/backend/src/bot/commands/message.rs
@@ -6,9 +6,9 @@ use twilight_http::error::ErrorType;
 use twilight_model::application::command::{Command, CommandType};
 use twilight_model::application::component::Component;
 use twilight_model::application::interaction::application_command::{
-    CommandDataOption, CommandOptionValue,
+    CommandData, CommandDataOption, CommandOptionValue,
 };
-use twilight_model::application::interaction::ApplicationCommand;
+use twilight_model::application::interaction::Interaction;
 use twilight_model::channel::embed::Embed;
 use twilight_model::channel::Message;
 use twilight_model::id::marker::{ChannelMarker, MessageMarker};
@@ -27,28 +27,24 @@ lazy_static! {
 
 pub fn command_definition() -> Command {
     CommandBuilder::new(
-        "message".into(),
-        "Get JSON for or restore a message on Embed Generator".into(),
+        "message",
+        "Get JSON for or restore a message on Embed Generator",
         CommandType::ChatInput,
     )
     .option(
-        SubCommandBuilder::new(
-            "restore".into(),
-            "Restore a message on Embed Generator".into(),
-        )
-        .option(
+        SubCommandBuilder::new("restore", "Restore a message on Embed Generator").option(
             StringBuilder::new(
-                "message_id_or_url".into(),
-                "ID or URL of the message you want to restore".into(),
+                "message_id_or_url",
+                "ID or URL of the message you want to restore",
             )
             .required(true),
         ),
     )
     .option(
-        SubCommandBuilder::new("dump".into(), "Get the JSON code for a message".into()).option(
+        SubCommandBuilder::new("dump", "Get the JSON code for a message").option(
             StringBuilder::new(
-                "message_id_or_url".into(),
-                "ID or URL of the message you want the JSON code for".into(),
+                "message_id_or_url",
+                "ID or URL of the message you want the JSON code for",
             )
             .required(true),
         ),
@@ -58,17 +54,18 @@ pub fn command_definition() -> Command {
 
 pub async fn handle_command(
     http: InteractionClient<'_>,
-    cmd: Box<ApplicationCommand>,
+    interaction: Interaction,
+    cmd: &CommandData,
 ) -> InteractionResult {
-    let sub_cmd = cmd.data.options.get(0).unwrap();
+    let sub_cmd = cmd.options.get(0).unwrap();
     let options = match &sub_cmd.value {
         CommandOptionValue::SubCommand(options) => options.clone(),
         _ => unreachable!(),
     };
 
     match sub_cmd.name.as_str() {
-        "restore" => handle_command_restore(http, cmd, options).await?,
-        "dump" => handle_command_dump(http, cmd, options).await?,
+        "restore" => handle_command_restore(http, interaction, options).await?,
+        "dump" => handle_command_dump(http, interaction, options).await?,
         _ => {}
     }
     Ok(())
@@ -92,23 +89,23 @@ fn parse_message_id_or_url(
 
 async fn get_message_from_id_or_url(
     http: &InteractionClient<'_>,
-    cmd: &ApplicationCommand,
+    interaction: &Interaction,
     message_id_or_url: &str,
 ) -> Result<Message, InteractionError> {
     let (channel_id, message_id) = match parse_message_id_or_url(&message_id_or_url) {
         Ok(v) => v,
         Err(e) => {
-            simple_response(&http, cmd.id, &cmd.token, e).await?;
+            simple_response(&http, interaction.id, &interaction.token, e).await?;
             return Err(InteractionError::NoOp);
         }
     };
 
-    let channel_id = channel_id.unwrap_or(cmd.channel_id);
-    if channel_id != cmd.channel_id {
+    let channel_id = channel_id.unwrap_or(interaction.channel_id.unwrap());
+    if channel_id != interaction.channel_id.unwrap() {
         simple_response(
             &http,
-            cmd.id,
-            &cmd.token,
+            interaction.id,
+            &interaction.token,
             "The message must belong to this channel".into(),
         )
         .await?;
@@ -123,8 +120,8 @@ async fn get_message_from_id_or_url(
                     404 => {
                         simple_response(
                             &http,
-                            cmd.id,
-                            &cmd.token,
+                            interaction.id,
+                            &interaction.token,
                             "Can't find the message in this channel".into(),
                         )
                         .await?;
@@ -159,7 +156,7 @@ pub fn message_to_dump(msg: Message) -> MessageDump {
 
 async fn handle_command_restore(
     http: InteractionClient<'_>,
-    cmd: Box<ApplicationCommand>,
+    interaction: &Interaction,
     mut options: Vec<CommandDataOption>,
 ) -> InteractionResult {
     let message_id_or_url = match options.pop().unwrap().value {
@@ -167,7 +164,7 @@ async fn handle_command_restore(
         _ => unreachable!(),
     };
 
-    let msg = get_message_from_id_or_url(&http, &cmd, &message_id_or_url).await?;
+    let msg = get_message_from_id_or_url(&http, interaction, &message_id_or_url).await?;
     let msg_dump = message_to_dump(msg);
 
     let client = awc::ClientBuilder::new().finish();
@@ -180,8 +177,8 @@ async fn handle_command_restore(
 
     simple_response(
         &http,
-        cmd.id,
-        &cmd.token,
+        interaction.id,
+        &interaction.token,
         format!(
             "You can edit the message here: https://discord.club/share/{}",
             resp.id
@@ -204,6 +201,7 @@ pub struct MessageDump {
 
 async fn handle_command_dump(
     http: InteractionClient<'_>,
+    interaction: Interaction,
     cmd: Box<ApplicationCommand>,
     mut options: Vec<CommandDataOption>,
 ) -> InteractionResult {
@@ -230,8 +228,8 @@ async fn handle_command_dump(
 
     simple_response(
         &http,
-        cmd.id,
-        &cmd.token,
+        interaction.id,
+        &interaction.token,
         format!(
             "You can find the JSON code here: <https://vaultb.in/{}>",
             resp.data.id

--- a/backend/src/bot/commands/message.rs
+++ b/backend/src/bot/commands/message.rs
@@ -55,7 +55,7 @@ pub fn command_definition() -> Command {
 pub async fn handle_command(
     http: InteractionClient<'_>,
     interaction: Interaction,
-    cmd: &CommandData,
+    cmd: Box<CommandData>,
 ) -> InteractionResult {
     let sub_cmd = cmd.options.get(0).unwrap();
     let options = match &sub_cmd.value {
@@ -156,7 +156,7 @@ pub fn message_to_dump(msg: Message) -> MessageDump {
 
 async fn handle_command_restore(
     http: InteractionClient<'_>,
-    interaction: &Interaction,
+    interaction: Interaction,
     mut options: Vec<CommandDataOption>,
 ) -> InteractionResult {
     let message_id_or_url = match options.pop().unwrap().value {
@@ -164,7 +164,7 @@ async fn handle_command_restore(
         _ => unreachable!(),
     };
 
-    let msg = get_message_from_id_or_url(&http, interaction, &message_id_or_url).await?;
+    let msg = get_message_from_id_or_url(&http, &interaction, &message_id_or_url).await?;
     let msg_dump = message_to_dump(msg);
 
     let client = awc::ClientBuilder::new().finish();
@@ -202,7 +202,6 @@ pub struct MessageDump {
 async fn handle_command_dump(
     http: InteractionClient<'_>,
     interaction: Interaction,
-    cmd: Box<ApplicationCommand>,
     mut options: Vec<CommandDataOption>,
 ) -> InteractionResult {
     let message_id_or_url = match options.pop().unwrap().value {
@@ -210,7 +209,7 @@ async fn handle_command_dump(
         _ => unreachable!(),
     };
 
-    let msg = get_message_from_id_or_url(&http, &cmd, &message_id_or_url).await?;
+    let msg = get_message_from_id_or_url(&http, &interaction, &message_id_or_url).await?;
 
     let msg_json = serde_json::to_string_pretty(&message_to_dump(msg))?;
 

--- a/backend/src/bot/commands/message_json_direct.rs
+++ b/backend/src/bot/commands/message_json_direct.rs
@@ -17,18 +17,17 @@ pub fn command_definition() -> Command {
 pub async fn handle_command(
     http: InteractionClient<'_>,
     interaction: Interaction,
-    cmd: &CommandData,
+    cmd: Box<CommandData>,
 ) -> InteractionResult {
     let msg_id = Id::new(cmd.target_id.unwrap().get());
     let msg = cmd
         .resolved
-        .as_ref()
         .unwrap()
         .messages
-        .get(&msg_id)
+        .remove(&msg_id)
         .unwrap();
 
-    let msg_json = serde_json::to_string_pretty(&message_to_dump(msg.clone()))?;
+    let msg_json = serde_json::to_string_pretty(&message_to_dump(msg))?;
 
     let client = awc::ClientBuilder::new().finish();
 

--- a/backend/src/bot/commands/message_json_direct.rs
+++ b/backend/src/bot/commands/message_json_direct.rs
@@ -1,6 +1,7 @@
 use twilight_http::client::InteractionClient;
 use twilight_model::application::command::{Command, CommandType};
-use twilight_model::application::interaction::ApplicationCommand;
+use twilight_model::application::interaction::application_command::CommandData;
+use twilight_model::application::interaction::Interaction;
 use twilight_model::id::Id;
 use twilight_util::builder::command::CommandBuilder;
 
@@ -10,17 +11,24 @@ use crate::bot::commands::message::{
 use crate::bot::commands::{simple_response, InteractionResult};
 
 pub fn command_definition() -> Command {
-    CommandBuilder::new("Dump Message".into(), "".into(), CommandType::Message).build()
+    CommandBuilder::new("Dump Message", "", CommandType::Message).build()
 }
 
 pub async fn handle_command(
     http: InteractionClient<'_>,
-    cmd: Box<ApplicationCommand>,
+    interaction: Interaction,
+    cmd: &CommandData,
 ) -> InteractionResult {
-    let msg_id = Id::new(cmd.data.target_id.unwrap().get());
-    let msg = cmd.data.resolved.unwrap().messages.remove(&msg_id).unwrap();
+    let msg_id = Id::new(cmd.target_id.unwrap().get());
+    let msg = cmd
+        .resolved
+        .as_ref()
+        .unwrap()
+        .messages
+        .get(&msg_id)
+        .unwrap();
 
-    let msg_json = serde_json::to_string_pretty(&message_to_dump(msg))?;
+    let msg_json = serde_json::to_string_pretty(&message_to_dump(msg.clone()))?;
 
     let client = awc::ClientBuilder::new().finish();
 
@@ -36,8 +44,8 @@ pub async fn handle_command(
 
     simple_response(
         &http,
-        cmd.id,
-        &cmd.token,
+        interaction.id,
+        &interaction.token,
         format!(
             "You can find the JSON code here: <https://vaultb.in/{}>",
             resp.data.id

--- a/backend/src/bot/commands/message_restore_direct.rs
+++ b/backend/src/bot/commands/message_restore_direct.rs
@@ -1,6 +1,7 @@
 use twilight_http::client::InteractionClient;
 use twilight_model::application::command::{Command, CommandType};
-use twilight_model::application::interaction::ApplicationCommand;
+use twilight_model::application::interaction::application_command::CommandData;
+use twilight_model::application::interaction::Interaction;
 use twilight_model::id::Id;
 use twilight_util::builder::command::CommandBuilder;
 
@@ -10,17 +11,18 @@ use crate::bot::commands::message::{
 use crate::bot::commands::{simple_response, InteractionResult};
 
 pub fn command_definition() -> Command {
-    CommandBuilder::new("Restore Message".into(), "".into(), CommandType::Message).build()
+    CommandBuilder::new("Restore Message", "", CommandType::Message).build()
 }
 
 pub async fn handle_command(
     http: InteractionClient<'_>,
-    cmd: Box<ApplicationCommand>,
+    interaction: Interaction,
+    cmd: &CommandData,
 ) -> InteractionResult {
-    let msg_id = Id::new(cmd.data.target_id.unwrap().get());
-    let msg = cmd.data.resolved.unwrap().messages.remove(&msg_id).unwrap();
+    let msg_id = Id::new(cmd.target_id.unwrap().get());
+    let msg = cmd.resolved.as_ref().unwrap().messages.get(&msg_id).unwrap();
 
-    let msg_dump = message_to_dump(msg);
+    let msg_dump = message_to_dump(msg.clone());
 
     let client = awc::ClientBuilder::new().finish();
 
@@ -33,8 +35,8 @@ pub async fn handle_command(
 
     simple_response(
         &http,
-        cmd.id,
-        &cmd.token,
+        interaction.id,
+        &interaction.token,
         format!(
             "You can edit the message here: https://discord.club/share/{}",
             resp.id

--- a/backend/src/bot/commands/message_restore_direct.rs
+++ b/backend/src/bot/commands/message_restore_direct.rs
@@ -17,12 +17,17 @@ pub fn command_definition() -> Command {
 pub async fn handle_command(
     http: InteractionClient<'_>,
     interaction: Interaction,
-    cmd: &CommandData,
+    cmd: Box<CommandData>,
 ) -> InteractionResult {
     let msg_id = Id::new(cmd.target_id.unwrap().get());
-    let msg = cmd.resolved.as_ref().unwrap().messages.get(&msg_id).unwrap();
+    let msg = cmd
+        .resolved
+        .unwrap()
+        .messages
+        .remove(&msg_id)
+        .unwrap();
 
-    let msg_dump = message_to_dump(msg.clone());
+    let msg_dump = message_to_dump(msg);
 
     let client = awc::ClientBuilder::new().finish();
 

--- a/backend/src/bot/commands/webhook.rs
+++ b/backend/src/bot/commands/webhook.rs
@@ -1,7 +1,7 @@
 use twilight_http::client::InteractionClient;
 use twilight_model::application::command::{Command, CommandType};
-use twilight_model::application::interaction::{ApplicationCommand, Interaction};
 use twilight_model::application::interaction::application_command::CommandData;
+use twilight_model::application::interaction::Interaction;
 use twilight_model::guild::Permissions;
 use twilight_model::id::marker::{ChannelMarker, InteractionMarker, WebhookMarker};
 use twilight_model::id::Id;
@@ -67,7 +67,7 @@ pub async fn get_webhook_for_channel(
 pub async fn handle_command(
     http: InteractionClient<'_>,
     interaction: Interaction,
-    _cmd: &CommandData,
+    _cmd: Box<CommandData>,
 ) -> InteractionResult {
     if !interaction
         .member
@@ -98,8 +98,13 @@ pub async fn handle_command(
         return Err(InteractionError::NoOp);
     }
 
-    let (webhook_id, webhook_token) =
-        get_webhook_for_channel(&http, interaction.channel_id.unwrap(), interaction.id, &interaction.token).await?;
+    let (webhook_id, webhook_token) = get_webhook_for_channel(
+        &http,
+        interaction.channel_id.unwrap(),
+        interaction.id,
+        &interaction.token,
+    )
+    .await?;
 
     simple_response(
         &http,

--- a/backend/src/bot/commands/website.rs
+++ b/backend/src/bot/commands/website.rs
@@ -18,7 +18,7 @@ pub fn command_definition() -> Command {
 pub async fn handle_command(
     http: InteractionClient<'_>,
     interaction: Interaction,
-    _cmd: &CommandData,
+    _cmd: Box<CommandData>,
 ) -> InteractionResult {
     simple_response(
         &http,

--- a/backend/src/bot/commands/website.rs
+++ b/backend/src/bot/commands/website.rs
@@ -1,14 +1,15 @@
 use twilight_http::client::InteractionClient;
 use twilight_model::application::command::{Command, CommandType};
-use twilight_model::application::interaction::ApplicationCommand;
+use twilight_model::application::interaction::application_command::CommandData;
+use twilight_model::application::interaction::Interaction;
 use twilight_util::builder::command::CommandBuilder;
 
 use crate::bot::commands::{simple_response, InteractionResult};
 
 pub fn command_definition() -> Command {
     CommandBuilder::new(
-        "website".into(),
-        "Embed Generator is primarily used through its website".into(),
+        "website",
+        "Embed Generator is primarily used through its website",
         CommandType::ChatInput,
     )
     .build()
@@ -16,12 +17,13 @@ pub fn command_definition() -> Command {
 
 pub async fn handle_command(
     http: InteractionClient<'_>,
-    cmd: Box<ApplicationCommand>,
+    interaction: Interaction,
+    _cmd: &CommandData,
 ) -> InteractionResult {
     simple_response(
         &http,
-        cmd.id,
-        &cmd.token,
+        interaction.id,
+        &interaction.token,
         "You can find the website of Embed Generator at: <https://discord.club>".into(),
     )
     .await?;


### PR DESCRIPTION
twilight-model 0.11 fails to parse some new discord features. This is most likely why some guilds are missing in the cache and can't use the bot correctly.
Updating to 0.12 requires some work tho