### PR TITLE
fix emoji selector

### DIFF
--- a/embedg-app/src/components/EmojiPicker.tsx
+++ b/embedg-app/src/components/EmojiPicker.tsx
@@ -82,7 +82,6 @@ export default function EmojiPicker({
               "flags",
             ]}
             theme="dark"
-            set="twitter"
           />
         </div>
       )}


### PR DESCRIPTION
The issue with some emoji not displaying the right emoji is related to a bad ID on the emoji. Seems to be caused by ``set=“twitter”``. Removing this prop, everything work. Probably because the fetch URL is already for the twitter set.