### PR TITLE
Permission check action

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ premium:
       default: true
       features:
         max_saved_messages: 25
-        max_actions_per_component: 2
+        max_actions_per_component: 3
         advanced_action_types: false
         ai_assistant: false
         is_premium: false
@@ -87,7 +87,7 @@ premium:
       sku_id: "123"
       features:
         max_saved_messages: 100
-        max_actions_per_component: 5
+        max_actions_per_component: 10
         advanced_action_types: true
         ai_assistant: true
         is_premium: true # This is used for handing out cosmetics like a role on the support server

--- a/embedg-app/src/components/Action.tsx
+++ b/embedg-app/src/components/Action.tsx
@@ -11,6 +11,8 @@ import SavedMessageSelect from "./SavedMessageSelect";
 import { useMemo } from "react";
 import { MessageAction } from "../discord/schema";
 import CheckBox from "./CheckBox";
+import { RolesSelect } from "./RolesSelect";
+import PermissionsSelect from "./PermissionsSelect";
 
 interface Props {
   guildId: string | null;
@@ -31,6 +33,8 @@ interface Props {
   setTargetId(targetId: string): void;
   setPublic(p: boolean): void;
   setDisableDefaultResponse(p: boolean): void;
+  setRoleIds(roleIds: string[]): void;
+  setPermissions(permissions: string): void;
 }
 
 const actionTypes = {
@@ -43,6 +47,7 @@ const actionTypes = {
   2: "Toggle Role",
   3: "Add Role",
   4: "Remove Role",
+  10: "Check Permissions",
 } as const;
 
 const actionDescriptions = {
@@ -55,6 +60,7 @@ const actionDescriptions = {
   7: "Send a saved message to the user via DM.",
   8: "Edit the message with a new text message.",
   9: "Edit the message with a saved message.",
+  10: "Check if the user has the required permissions or roles.",
 } as const;
 
 export default function Action({
@@ -74,6 +80,8 @@ export default function Action({
   setTargetId,
   setPublic,
   setDisableDefaultResponse,
+  setRoleIds,
+  setPermissions,
 }: Props) {
   const actionTypeGroup = useMemo(() => {
     switch (action.type) {
@@ -91,6 +99,8 @@ export default function Action({
         return "add_role";
       case 4:
         return "remove_role";
+      case 10:
+        return "check_permissions";
     }
   }, [action.type]);
 
@@ -110,6 +120,9 @@ export default function Action({
         break;
       case "remove_role":
         setType(4);
+        break;
+      case "check_permissions":
+        setType(10);
         break;
     }
   }
@@ -217,6 +230,7 @@ export default function Action({
                 <option value="toggle_role">Toggle Role</option>
                 <option value="add_role">Add Role</option>
                 <option value="remove_role">Remove Role</option>
+                <option value="check_permissions">Check Permissions</option>
               </select>
             </div>
             {(actionTypeGroup === "text_response" ||
@@ -248,7 +262,10 @@ export default function Action({
                 <CheckBox checked={action.public} onChange={setPublic} />
               </div>
             )}
-            {(action.type === 2 || action.type === 3 || action.type === 4) && (
+            {(action.type === 2 ||
+              action.type === 3 ||
+              action.type === 4 ||
+              action.type === 10) && (
               <div className="flex-none">
                 <div className="mb-1.5 flex">
                   <div className="uppercase text-gray-300 text-sm font-medium">
@@ -282,6 +299,41 @@ export default function Action({
               messageId={action.target_id || null}
               onChange={(v) => setTargetId(v || "")}
             />
+          ) : action.type === 10 ? (
+            <>
+              <div className="flex-none">
+                <div className="mb-1.5 flex">
+                  <div className="uppercase text-gray-300 text-sm font-medium">
+                    Required Permissions
+                  </div>
+                </div>
+                <PermissionsSelect
+                  permissions={action.permissions}
+                  onChange={setPermissions}
+                />
+              </div>
+              <div className="flex-none">
+                <div className="mb-1.5 flex">
+                  <div className="uppercase text-gray-300 text-sm font-medium">
+                    Required Roles
+                  </div>
+                </div>
+                <RolesSelect
+                  guildId={guildId}
+                  roleIds={action.role_ids}
+                  onChange={setRoleIds}
+                />
+              </div>
+              {action.disable_default_response && (
+                <EditorInput
+                  label="Error Response"
+                  type="textarea"
+                  value={action.text || ""}
+                  onChange={(v) => setText(v)}
+                  controls={true}
+                />
+              )}
+            </>
           ) : null}
 
           <div className="text-gray-500 text-sm whitespace-normal">

--- a/embedg-app/src/components/Action.tsx
+++ b/embedg-app/src/components/Action.tsx
@@ -60,7 +60,7 @@ const actionDescriptions = {
   7: "Send a saved message to the user via DM.",
   8: "Edit the message with a new text message.",
   9: "Edit the message with a saved message.",
-  10: "Check if the user has the required permissions or roles.",
+  10: "Check if the user has the required permissions and roles.",
 } as const;
 
 export default function Action({

--- a/embedg-app/src/components/CommandAction.tsx
+++ b/embedg-app/src/components/CommandAction.tsx
@@ -57,17 +57,26 @@ export default function EditorAction({ cmdId, actionIndex }: Props) {
     shallow
   );
 
-  const [setType, setText, setTargetId, setPublic, setDisableDefaultResponse] =
-    useCommandActionsStore(
-      (state) => [
-        state.setActionType,
-        state.setActionText,
-        state.setActionTargetId,
-        state.setActionPublic,
-        state.setActionDisableDefaultResponse,
-      ],
-      shallow
-    );
+  const [
+    setType,
+    setText,
+    setTargetId,
+    setPublic,
+    setDisableDefaultResponse,
+    setRoleIds,
+    setPermissions,
+  ] = useCommandActionsStore(
+    (state) => [
+      state.setActionType,
+      state.setActionText,
+      state.setActionTargetId,
+      state.setActionPublic,
+      state.setActionDisableDefaultResponse,
+      state.setActionRoleIds,
+      state.setActionPermissions,
+    ],
+    shallow
+  );
 
   return (
     <Action
@@ -87,6 +96,10 @@ export default function EditorAction({ cmdId, actionIndex }: Props) {
       setPublic={(public_) => setPublic(cmdId, actionIndex, public_)}
       setDisableDefaultResponse={(disable) =>
         setDisableDefaultResponse(cmdId, actionIndex, disable)
+      }
+      setRoleIds={(roleIds) => setRoleIds(cmdId, actionIndex, roleIds)}
+      setPermissions={(permissions) =>
+        setPermissions(cmdId, actionIndex, permissions)
       }
     />
   );

--- a/embedg-app/src/components/EditorAction.tsx
+++ b/embedg-app/src/components/EditorAction.tsx
@@ -57,17 +57,26 @@ export default function EditorAction({ setId, actionIndex }: Props) {
     shallow
   );
 
-  const [setType, setText, setTargetId, setPublic, setDisableDefaultResponse] =
-    useCurrentMessageStore(
-      (state) => [
-        state.setActionType,
-        state.setActionText,
-        state.setActionTargetId,
-        state.setActionPublic,
-        state.setActionDisableDefaultResponse,
-      ],
-      shallow
-    );
+  const [
+    setType,
+    setText,
+    setTargetId,
+    setPublic,
+    setDisableDefaultResponse,
+    setRoleIds,
+    setPermissions,
+  ] = useCurrentMessageStore(
+    (state) => [
+      state.setActionType,
+      state.setActionText,
+      state.setActionTargetId,
+      state.setActionPublic,
+      state.setActionDisableDefaultResponse,
+      state.setActionRoleIds,
+      state.setActionPermissions,
+    ],
+    shallow
+  );
 
   return (
     <Action
@@ -89,6 +98,8 @@ export default function EditorAction({ setId, actionIndex }: Props) {
       setDisableDefaultResponse={(disable) =>
         setDisableDefaultResponse(setId, actionIndex, disable)
       }
+      setRoleIds={(ids) => setRoleIds(setId, actionIndex, ids)}
+      setPermissions={(perms) => setPermissions(setId, actionIndex, perms)}
     />
   );
 }

--- a/embedg-app/src/components/PermissionsSelect.tsx
+++ b/embedg-app/src/components/PermissionsSelect.tsx
@@ -1,7 +1,10 @@
 import { useMemo, useState } from "react";
 import ClickOutsideHandler from "./ClickOutsideHandler";
-import { colorIntToHex } from "../util/discord";
-import { CheckIcon, ChevronDownIcon } from "@heroicons/react/20/solid";
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  ShieldExclamationIcon,
+} from "@heroicons/react/20/solid";
 import clsx from "clsx";
 
 interface Props {
@@ -93,10 +96,7 @@ export default function PermissionsSelect({ permissions, onChange }: Props) {
           {activeFlags.length ? (
             <div className="flex items-center space-x-2 cursor-pointer w-full">
               <div className="flex-auto flex space-x-2 items-center">
-                <div
-                  className="h-4 w-4 rounded-full"
-                  style={{ backgroundColor: colorIntToHex(200) }}
-                ></div>
+                <ShieldExclamationIcon className="h-5 w-5 text-gray-500" />
                 <div className="text-gray-300 truncate">
                   {activeFlags[0].replaceAll("_", " ")}
                 </div>
@@ -129,10 +129,7 @@ export default function PermissionsSelect({ permissions, onChange }: Props) {
                 role="button"
                 onClick={() => togglePermission(f)}
               >
-                <div
-                  className="h-4 w-4 rounded-full"
-                  style={{ backgroundColor: colorIntToHex(200) }}
-                ></div>
+                <ShieldExclamationIcon className="h-5 w-5 text-gray-500" />
                 <div className="text-gray-300 truncate flex-auto">
                   {f.replaceAll("_", " ")}
                 </div>

--- a/embedg-app/src/components/PermissionsSelect.tsx
+++ b/embedg-app/src/components/PermissionsSelect.tsx
@@ -1,0 +1,149 @@
+import { useMemo, useState } from "react";
+import ClickOutsideHandler from "./ClickOutsideHandler";
+import { colorIntToHex } from "../util/discord";
+import { CheckIcon, ChevronDownIcon } from "@heroicons/react/20/solid";
+import clsx from "clsx";
+
+interface Props {
+  permissions: string;
+  onChange: (permissions: string) => void;
+}
+
+const permissionFlags: Record<string, bigint> = {
+  CREATE_INSTANT_INVITE: BigInt("0x0000000000000001"),
+  KICK_MEMBERS: BigInt("0x0000000000000002"),
+  BAN_MEMBERS: BigInt("0x0000000000000004"),
+  ADMINISTRATOR: BigInt("0x0000000000000008"),
+  MANAGE_CHANNELS: BigInt("0x0000000000000010"),
+  MANAGE_GUILD: BigInt("0x0000000000000020"),
+  ADD_REACTIONS: BigInt("0x0000000000000040"),
+  VIEW_AUDIT_LOG: BigInt("0x0000000000000080"),
+  PRIORITY_SPEAKER: BigInt("0x0000000000000100"),
+  STREAM: BigInt("0x0000000000000200"),
+  VIEW_CHANNEL: BigInt("0x0000000000000400"),
+  SEND_MESSAGES: BigInt("0x0000000000000800"),
+  SEND_TTS_MESSAGES: BigInt("0x0000000000001000"),
+  MANAGE_MESSAGES: BigInt("0x0000000000002000"),
+  EMBED_LINKS: BigInt("0x0000000000004000"),
+  ATTACH_FILES: BigInt("0x0000000000008000"),
+  READ_MESSAGE_HISTORY: BigInt("0x0000000000010000"),
+  MENTION_EVERYONE: BigInt("0x0000000000020000"),
+  USE_EXTERNAL_EMOJIS: BigInt("0x0000000000040000"),
+  VIEW_GUILD_INSIGHTS: BigInt("0x0000000000080000"),
+  CONNECT: BigInt("0x0000000000100000"),
+  SPEAK: BigInt("0x0000000000200000"),
+  MUTE_MEMBERS: BigInt("0x0000000000400000"),
+  DEAFEN_MEMBERS: BigInt("0x0000000000800000"),
+  MOVE_MEMBERS: BigInt("0x0000000001000000"),
+  USE_VAD: BigInt("0x0000000002000000"),
+  CHANGE_NICKNAME: BigInt("0x0000000004000000"),
+  MANAGE_NICKNAMES: BigInt("0x0000000008000000"),
+  MANAGE_ROLES: BigInt("0x0000000010000000"),
+  MANAGE_WEBHOOKS: BigInt("0x0000000020000000"),
+  MANAGE_GUILD_EXPRESSIONS: BigInt("0x0000000040000000"),
+  USE_APPLICATION_COMMANDS: BigInt("0x0000000080000000"),
+  REQUEST_TO_SPEAK: BigInt("0x0000000100000000"),
+  MANAGE_EVENTS: BigInt("0x0000000200000000"),
+  MANAGE_THREADS: BigInt("0x0000000400000000"),
+  CREATE_PUBLIC_THREADS: BigInt("0x0000000800000000"),
+  CREATE_PRIVATE_THREADS: BigInt("0x0000001000000000"),
+  USE_EXTERNAL_STICKERS: BigInt("0x0000002000000000"),
+  SEND_MESSAGES_IN_THREADS: BigInt("0x0000004000000000"),
+  USE_EMBEDDED_ACTIVITIES: BigInt("0x0000008000000000"),
+  MODERATE_MEMBERS: BigInt("0x0000010000000000"),
+  VIEW_CREATOR_MONETIZATION_ANALYTICS: BigInt("0x0000020000000000"),
+  USE_SOUNDBOARD: BigInt("0x0000040000000000"),
+  CREATE_GUILD_EXPRESSIONS: BigInt("0x0000080000000000"),
+  CREATE_EVENTS: BigInt("0x0000100000000000"),
+  USE_EXTERNAL_SOUNDS: BigInt("0x0000200000000000"),
+  SEND_VOICE_MESSAGES: BigInt("0x0000400000000000"),
+  SEND_POLLS: BigInt("0x0002000000000000"),
+};
+
+export default function PermissionsSelect({ permissions, onChange }: Props) {
+  const permissionsInt = useMemo(() => BigInt(permissions), [permissions]);
+
+  const activeFlags = useMemo(
+    () =>
+      Object.keys(permissionFlags).filter(
+        (f) => permissionsInt & permissionFlags[f]
+      ),
+    [permissionsInt]
+  );
+
+  function togglePermission(flag: string) {
+    if (permissionsInt & permissionFlags[flag]) {
+      onChange((permissionsInt ^ permissionFlags[flag]).toString());
+      return;
+    } else {
+      onChange((permissionsInt | permissionFlags[flag]).toString());
+    }
+  }
+
+  const [open, setOpen] = useState(false);
+
+  return (
+    <ClickOutsideHandler onClickOutside={() => setOpen(false)}>
+      <div className="px-3 h-10 flex items-center rounded bg-dark-2 relative select-none">
+        <div
+          role="button"
+          onClick={() => setOpen((prev) => !prev)}
+          className="flex-auto"
+        >
+          {activeFlags.length ? (
+            <div className="flex items-center space-x-2 cursor-pointer w-full">
+              <div className="flex-auto flex space-x-2 items-center">
+                <div
+                  className="h-4 w-4 rounded-full"
+                  style={{ backgroundColor: colorIntToHex(200) }}
+                ></div>
+                <div className="text-gray-300 truncate">
+                  {activeFlags[0].replaceAll("_", " ")}
+                </div>
+                {activeFlags.length > 1 && (
+                  <div className="text-gray-400 font-light">
+                    + {activeFlags.length - 1} others
+                  </div>
+                )}
+              </div>
+              <ChevronDownIcon
+                className={clsx(
+                  "text-white w-5 h-5 flex-none transition-transform",
+                  open && "rotate-180"
+                )}
+              />
+            </div>
+          ) : (
+            <div className="text-gray-300">Select permissions</div>
+          )}
+        </div>
+        {open && (
+          <div className="absolute bg-dark-2 top-14 left-0 rounded shadow-lg w-full border-2 border-dark-2 z-10 max-h-48 overflow-y-auto overflow-x-none">
+            {Object.keys(permissionFlags).map((f) => (
+              <div
+                key={f}
+                className={clsx(
+                  "py-2 flex space-x-2 items-center hover:bg-dark-3 hover:bg-opacity-100 rounded cursor-pointer px-3",
+                  activeFlags.includes(f) && "bg-dark-3 bg-opacity-50"
+                )}
+                role="button"
+                onClick={() => togglePermission(f)}
+              >
+                <div
+                  className="h-4 w-4 rounded-full"
+                  style={{ backgroundColor: colorIntToHex(200) }}
+                ></div>
+                <div className="text-gray-300 truncate flex-auto">
+                  {f.replaceAll("_", " ")}
+                </div>
+                {activeFlags.includes(f) && (
+                  <CheckIcon className="h-5 w-5 text-gray-300" />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </ClickOutsideHandler>
+  );
+}

--- a/embedg-app/src/components/PremiumFeatures.tsx
+++ b/embedg-app/src/components/PremiumFeatures.tsx
@@ -36,8 +36,8 @@ export default function PremiumFeatures() {
       <div className="p-4 bg-dark-3 rounded flex space-x-3 items-center">
         <FireIcon className="w-5 h-5 text-green flex-none" />
         <div className="text-gray-400 font-light text-sm">
-          Add up to <span className="font-medium text-white">5 actions</span> to
-          each interactive component and save up to{" "}
+          Add up to <span className="font-medium text-white">10 actions</span>{" "}
+          to each interactive component and save up to{" "}
           <span className="font-medium text-white">100 messages</span>
         </div>
       </div>

--- a/embedg-app/src/components/RolesSelect.tsx
+++ b/embedg-app/src/components/RolesSelect.tsx
@@ -1,0 +1,105 @@
+import { CheckIcon, ChevronDownIcon } from "@heroicons/react/20/solid";
+import clsx from "clsx";
+import { useEffect, useMemo, useState } from "react";
+import ClickOutsideHandler from "./ClickOutsideHandler";
+import { useGuildRolesQuery } from "../api/queries";
+import { colorIntToHex } from "../util/discord";
+
+interface Props {
+  guildId: string | null;
+  roleIds: string[];
+  onChange: (roleId: string[]) => void;
+}
+
+export function RolesSelect({ guildId, roleIds, onChange }: Props) {
+  const { data: roles } = useGuildRolesQuery(guildId);
+
+  const firstRole = useMemo(
+    () => roles?.success && roles.data.find((r) => r.id === roleIds[0]),
+    [roles, roleIds[0]]
+  );
+
+  function toggleRole(roleId: string) {
+    if (roleIds.includes(roleId)) {
+      onChange(roleIds.filter((r) => r !== roleId));
+      return;
+    } else {
+      onChange([...roleIds, roleId]);
+    }
+  }
+
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (roles?.success) {
+      roles.data.sort((a, b) => b.position - a.position);
+    }
+  }, [roles]);
+
+  return (
+    <ClickOutsideHandler onClickOutside={() => setOpen(false)}>
+      <div className="px-3 h-10 flex items-center rounded bg-dark-2 relative select-none">
+        <div
+          role="button"
+          onClick={() => setOpen((prev) => !prev)}
+          className="flex-auto"
+        >
+          {firstRole ? (
+            <div className="flex items-center space-x-2 cursor-pointer w-full">
+              <div className="flex-auto flex space-x-2 items-center">
+                <div
+                  className="h-4 w-4 rounded-full"
+                  style={{ backgroundColor: colorIntToHex(firstRole.color) }}
+                ></div>
+                <div className="text-gray-300 truncate">{firstRole.name}</div>
+                {roleIds.length > 1 && (
+                  <div className="text-gray-400 font-light">
+                    + {roleIds.length - 1} others
+                  </div>
+                )}
+              </div>
+              <ChevronDownIcon
+                className={clsx(
+                  "text-white w-5 h-5 flex-none transition-transform",
+                  open && "rotate-180"
+                )}
+              />
+            </div>
+          ) : (
+            <div className="text-gray-300">Select roles</div>
+          )}
+        </div>
+        {open && (
+          <div className="absolute bg-dark-2 top-14 left-0 rounded shadow-lg w-full border-2 border-dark-2 z-10 max-h-48 overflow-y-auto overflow-x-none">
+            {roles?.success && roles.data.length ? (
+              roles.data.map((r) => (
+                <div
+                  key={r.id}
+                  className={clsx(
+                    "py-2 flex space-x-2 items-center hover:bg-dark-3 hover:bg-opacity-100 rounded cursor-pointer px-3",
+                    roleIds.includes(r.id) && "bg-dark-3 bg-opacity-50"
+                  )}
+                  role="button"
+                  onClick={() => toggleRole(r.id)}
+                >
+                  <div
+                    className="h-4 w-4 rounded-full"
+                    style={{ backgroundColor: colorIntToHex(r.color) }}
+                  ></div>
+                  <div className="text-gray-300 truncate flex-auto">
+                    {r.name}
+                  </div>
+                  {roleIds.includes(r.id) && (
+                    <CheckIcon className="h-5 w-5 text-gray-300" />
+                  )}
+                </div>
+              ))
+            ) : (
+              <div className="p-2 text-gray-300">No roles found</div>
+            )}
+          </div>
+        )}
+      </div>
+    </ClickOutsideHandler>
+  );
+}

--- a/embedg-app/src/discord/restoreSchema.ts
+++ b/embedg-app/src/discord/restoreSchema.ts
@@ -330,6 +330,26 @@ export const messageActionSchema = z
         z.boolean().default(false)
       ),
     })
+  )
+  .or(
+    z.object({
+      type: z.literal(10), // permission check
+      id: uniqueIdSchema.default(() => getUniqueId()),
+      permissions: z.preprocess((d) => d ?? undefined, z.string().default("0")),
+      role_ids: z.preprocess(
+        (d) => d ?? undefined,
+        z.array(z.string()).default([])
+      ),
+      require_all: z.preprocess(
+        (d) => d ?? undefined,
+        z.boolean().default(false)
+      ), // require all roles
+      disable_default_response: z.preprocess(
+        (d) => d ?? undefined,
+        z.boolean().default(false)
+      ),
+      text: z.preprocess((d) => d ?? undefined, z.string().default("")),
+    })
   );
 
 export type MessageAction = z.infer<typeof messageActionSchema>;

--- a/embedg-app/src/discord/restoreSchema.ts
+++ b/embedg-app/src/discord/restoreSchema.ts
@@ -340,10 +340,6 @@ export const messageActionSchema = z
         (d) => d ?? undefined,
         z.array(z.string()).default([])
       ),
-      require_all: z.preprocess(
-        (d) => d ?? undefined,
-        z.boolean().default(false)
-      ), // require all roles
       disable_default_response: z.preprocess(
         (d) => d ?? undefined,
         z.boolean().default(false)

--- a/embedg-app/src/discord/schema.ts
+++ b/embedg-app/src/discord/schema.ts
@@ -318,12 +318,21 @@ export const messageActionSchema = z
   )
   .or(
     z.object({
-      type: z.literal(10), // permission check
+      type: z.literal(10), // permission check with default response
       id: uniqueIdSchema.default(() => getUniqueId()),
       permissions: z.string().default("0"),
       role_ids: z.array(z.string()),
-      disable_default_response: z.boolean().default(false),
-      text: z.optional(z.string().min(1).max(2000)),
+      disable_default_response: z.literal(false),
+    })
+  )
+  .or(
+    z.object({
+      type: z.literal(10), // permission check with custom response
+      id: uniqueIdSchema.default(() => getUniqueId()),
+      permissions: z.string().default("0"),
+      role_ids: z.array(z.string()),
+      disable_default_response: z.literal(true),
+      text: z.string().min(1).max(2000),
     })
   );
 

--- a/embedg-app/src/discord/schema.ts
+++ b/embedg-app/src/discord/schema.ts
@@ -322,7 +322,6 @@ export const messageActionSchema = z
       id: uniqueIdSchema.default(() => getUniqueId()),
       permissions: z.string().default("0"),
       role_ids: z.array(z.string()),
-      require_all: z.boolean().default(false), // require all roles
       disable_default_response: z.boolean().default(false),
       text: z.optional(z.string().min(1).max(2000)),
     })

--- a/embedg-app/src/discord/schema.ts
+++ b/embedg-app/src/discord/schema.ts
@@ -315,6 +315,17 @@ export const messageActionSchema = z
       public: z.boolean().default(false),
       disable_default_response: z.boolean().default(false),
     })
+  )
+  .or(
+    z.object({
+      type: z.literal(10), // permission check
+      id: uniqueIdSchema.default(() => getUniqueId()),
+      permissions: z.string().default("0"),
+      role_ids: z.array(z.string()),
+      require_all: z.boolean().default(false), // require all roles
+      disable_default_response: z.boolean().default(false),
+      text: z.optional(z.string().min(1).max(2000)),
+    })
   );
 
 export type MessageAction = z.infer<typeof messageActionSchema>;

--- a/embedg-app/src/state/actions.ts
+++ b/embedg-app/src/state/actions.ts
@@ -141,11 +141,11 @@ export const createActionStore = (key: string) =>
             set((state) => {
               const actionSet = state.actions[id];
               const action = actionSet.actions[i];
-              if (
-                action.type === 1 ||
-                action.type === 6 ||
-                action.type === 8 ||
-                action.type === 10
+              if (action.type === 1 || action.type === 6 || action.type === 8) {
+                action.text = text;
+              } else if (
+                action.type === 10 &&
+                action.disable_default_response
               ) {
                 action.text = text;
               }

--- a/embedg-app/src/state/actions.ts
+++ b/embedg-app/src/state/actions.ts
@@ -22,6 +22,9 @@ export interface ActionsStore {
     i: number,
     val: boolean
   ) => void;
+  setActionPermissions: (id: string, i: number, val: string) => void;
+  setActionRoleIds: (id: string, i: number, val: string[]) => void;
+  setActionRequireAll: (id: string, i: number, val: boolean) => void;
 
   actions: Record<string, MessageActionSet>;
 }
@@ -125,13 +128,27 @@ export const createActionStore = (key: string) =>
                   public: false,
                   disable_default_response: false,
                 };
+              } else if (type === 10) {
+                actionSet.actions[i] = {
+                  type,
+                  id: action.id,
+                  permissions: "0",
+                  role_ids: [],
+                  require_all: false,
+                  disable_default_response: false,
+                };
               }
             }),
           setActionText: (id: string, i: number, text: string) =>
             set((state) => {
               const actionSet = state.actions[id];
               const action = actionSet.actions[i];
-              if (action.type === 1 || action.type === 6 || action.type === 8) {
+              if (
+                action.type === 1 ||
+                action.type === 6 ||
+                action.type === 8 ||
+                action.type === 10
+              ) {
                 action.text = text;
               }
             }),
@@ -154,7 +171,9 @@ export const createActionStore = (key: string) =>
             set((state) => {
               const actionSet = state.actions[id];
               const action = actionSet.actions[i];
-              action.public = val;
+              if (action.type !== 10) {
+                action.public = val;
+              }
             }),
           setActionDisableDefaultResponse: (
             id: string,
@@ -164,8 +183,37 @@ export const createActionStore = (key: string) =>
             set((state) => {
               const actionSet = state.actions[id];
               const action = actionSet.actions[i];
-              if (action.type === 2 || action.type === 3 || action.type === 4) {
+              if (
+                action.type === 2 ||
+                action.type === 3 ||
+                action.type === 4 ||
+                action.type === 10
+              ) {
                 action.disable_default_response = val;
+              }
+            }),
+          setActionPermissions: (id: string, i: number, val: string) =>
+            set((state) => {
+              const actionSet = state.actions[id];
+              const action = actionSet.actions[i];
+              if (action.type === 10) {
+                action.permissions = val;
+              }
+            }),
+          setActionRoleIds: (id: string, i: number, val: string[]) =>
+            set((state) => {
+              const actionSet = state.actions[id];
+              const action = actionSet.actions[i];
+              if (action.type === 10) {
+                action.role_ids = val;
+              }
+            }),
+          setActionRequireAll: (id: string, i: number, val: boolean) =>
+            set((state) => {
+              const actionSet = state.actions[id];
+              const action = actionSet.actions[i];
+              if (action.type === 10) {
+                action.require_all = val;
               }
             }),
         }),

--- a/embedg-app/src/state/actions.ts
+++ b/embedg-app/src/state/actions.ts
@@ -24,7 +24,6 @@ export interface ActionsStore {
   ) => void;
   setActionPermissions: (id: string, i: number, val: string) => void;
   setActionRoleIds: (id: string, i: number, val: string[]) => void;
-  setActionRequireAll: (id: string, i: number, val: boolean) => void;
 
   actions: Record<string, MessageActionSet>;
 }
@@ -134,7 +133,6 @@ export const createActionStore = (key: string) =>
                   id: action.id,
                   permissions: "0",
                   role_ids: [],
-                  require_all: false,
                   disable_default_response: false,
                 };
               }
@@ -206,14 +204,6 @@ export const createActionStore = (key: string) =>
               const action = actionSet.actions[i];
               if (action.type === 10) {
                 action.role_ids = val;
-              }
-            }),
-          setActionRequireAll: (id: string, i: number, val: boolean) =>
-            set((state) => {
-              const actionSet = state.actions[id];
-              const action = actionSet.actions[i];
-              if (action.type === 10) {
-                action.require_all = val;
               }
             }),
         }),

--- a/embedg-app/src/state/message.ts
+++ b/embedg-app/src/state/message.ts
@@ -135,7 +135,6 @@ export interface MessageStore extends Message {
   ) => void;
   setActionPermissions: (id: string, i: number, val: string) => void;
   setActionRoleIds: (id: string, i: number, val: string[]) => void;
-  setActionRequireAll: (id: string, i: number, val: boolean) => void;
 
   getSelectMenu: (i: number, j: number) => MessageComponentSelectMenu | null;
   getButton: (i: number, j: number) => MessageComponentButton | null;
@@ -1115,7 +1114,6 @@ export const createMessageStore = (key: string) =>
                     id: action.id,
                     permissions: "0",
                     role_ids: [],
-                    require_all: false,
                     disable_default_response: false,
                   };
                 }
@@ -1187,14 +1185,6 @@ export const createMessageStore = (key: string) =>
                 const action = actionSet.actions[i];
                 if (action.type === 10) {
                   action.role_ids = val;
-                }
-              }),
-            setActionRequireAll: (id: string, i: number, val: boolean) =>
-              set((state) => {
-                const actionSet = state.actions[id];
-                const action = actionSet.actions[i];
-                if (action.type === 10) {
-                  action.require_all = val;
                 }
               }),
 

--- a/embedg-app/src/state/message.ts
+++ b/embedg-app/src/state/message.ts
@@ -133,6 +133,9 @@ export interface MessageStore extends Message {
     i: number,
     val: boolean
   ) => void;
+  setActionPermissions: (id: string, i: number, val: string) => void;
+  setActionRoleIds: (id: string, i: number, val: string[]) => void;
+  setActionRequireAll: (id: string, i: number, val: boolean) => void;
 
   getSelectMenu: (i: number, j: number) => MessageComponentSelectMenu | null;
   getButton: (i: number, j: number) => MessageComponentButton | null;
@@ -1106,6 +1109,15 @@ export const createMessageStore = (key: string) =>
                     public: false,
                     disable_default_response: false,
                   };
+                } else if (type === 10) {
+                  actionSet.actions[i] = {
+                    type,
+                    id: action.id,
+                    permissions: "0",
+                    role_ids: [],
+                    require_all: false,
+                    disable_default_response: false,
+                  };
                 }
               }),
             setActionText: (id: string, i: number, text: string) =>
@@ -1115,7 +1127,8 @@ export const createMessageStore = (key: string) =>
                 if (
                   action.type === 1 ||
                   action.type === 6 ||
-                  action.type === 8
+                  action.type === 8 ||
+                  action.type === 10
                 ) {
                   action.text = text;
                 }
@@ -1139,7 +1152,9 @@ export const createMessageStore = (key: string) =>
               set((state) => {
                 const actionSet = state.actions[id];
                 const action = actionSet.actions[i];
-                action.public = val;
+                if (action.type !== 10) {
+                  action.public = val;
+                }
               }),
             setActionDisableDefaultResponse: (
               id: string,
@@ -1152,9 +1167,34 @@ export const createMessageStore = (key: string) =>
                 if (
                   action.type === 2 ||
                   action.type === 3 ||
-                  action.type === 4
+                  action.type === 4 ||
+                  action.type === 10
                 ) {
                   action.disable_default_response = val;
+                }
+              }),
+            setActionPermissions: (id: string, i: number, val: string) =>
+              set((state) => {
+                const actionSet = state.actions[id];
+                const action = actionSet.actions[i];
+                if (action.type === 10) {
+                  action.permissions = val;
+                }
+              }),
+            setActionRoleIds: (id: string, i: number, val: string[]) =>
+              set((state) => {
+                const actionSet = state.actions[id];
+                const action = actionSet.actions[i];
+                if (action.type === 10) {
+                  action.role_ids = val;
+                }
+              }),
+            setActionRequireAll: (id: string, i: number, val: boolean) =>
+              set((state) => {
+                const actionSet = state.actions[id];
+                const action = actionSet.actions[i];
+                if (action.type === 10) {
+                  action.require_all = val;
                 }
               }),
 

--- a/embedg-app/src/state/message.ts
+++ b/embedg-app/src/state/message.ts
@@ -1125,8 +1125,12 @@ export const createMessageStore = (key: string) =>
                 if (
                   action.type === 1 ||
                   action.type === 6 ||
-                  action.type === 8 ||
-                  action.type === 10
+                  action.type === 8
+                ) {
+                  action.text = text;
+                } else if (
+                  action.type === 10 &&
+                  action.disable_default_response
                 ) {
                   action.text = text;
                 }

--- a/embedg-server/actions/data.go
+++ b/embedg-server/actions/data.go
@@ -70,7 +70,6 @@ type Action struct {
 	DisableDefaultResponse bool       `json:"disable_default_response"`
 	Permissions            string     `json:"permissions"`
 	RoleIDs                []string   `json:"role_ids"`
-	RequireAll             bool       `json:"require_all"`
 }
 
 type ActionSet struct {

--- a/embedg-server/actions/data.go
+++ b/embedg-server/actions/data.go
@@ -59,6 +59,7 @@ const (
 	ActionTypeSavedMessageDM       ActionType = 7
 	ActionTypeTextEdit             ActionType = 8
 	ActionTypeSavedMessageEdit     ActionType = 9
+	ActionTypePermissionCheck      ActionType = 10
 )
 
 type Action struct {
@@ -67,6 +68,9 @@ type Action struct {
 	Text                   string     `json:"text"`
 	Public                 bool       `json:"public"`
 	DisableDefaultResponse bool       `json:"disable_default_response"`
+	Permissions            string     `json:"permissions"`
+	RoleIDs                []string   `json:"role_ids"`
+	RequireAll             bool       `json:"require_all"`
 }
 
 type ActionSet struct {

--- a/embedg-server/actions/handler/handle.go
+++ b/embedg-server/actions/handler/handle.go
@@ -427,7 +427,7 @@ func (m *ActionHandler) HandleActionInteraction(s *discordgo.Session, i Interact
 			perms, _ := strconv.ParseInt(action.Permissions, 10, 64)
 
 			if interaction.Member.Permissions&perms != perms {
-				responseText := "You don't have the required permissions to use this command."
+				responseText := "You don't have the required permissions to use this component or command."
 				if action.DisableDefaultResponse {
 					responseText = action.Text
 				}
@@ -439,7 +439,7 @@ func (m *ActionHandler) HandleActionInteraction(s *discordgo.Session, i Interact
 				return nil
 			}
 
-			responseText := "You don't have the required roles to use this command."
+			responseText := "You don't have the required roles to use this component or command."
 			if action.DisableDefaultResponse {
 				responseText = action.Text
 			}

--- a/embedg-server/actions/handler/handle.go
+++ b/embedg-server/actions/handler/handle.go
@@ -445,25 +445,14 @@ func (m *ActionHandler) HandleActionInteraction(s *discordgo.Session, i Interact
 			}
 
 			if len(action.RoleIDs) != 0 {
-				hasOneRole := false
 				for _, roleID := range action.RoleIDs {
-					if slices.Contains(interaction.Member.Roles, roleID) {
-						hasOneRole = true
-					} else if action.RequireAll {
+					if !slices.Contains(interaction.Member.Roles, roleID) {
 						i.Respond(&discordgo.InteractionResponseData{
 							Content: responseText,
 							Flags:   discordgo.MessageFlagsEphemeral,
 						})
 						return nil
 					}
-				}
-
-				if !hasOneRole {
-					i.Respond(&discordgo.InteractionResponseData{
-						Content: responseText,
-						Flags:   discordgo.MessageFlagsEphemeral,
-					})
-					return nil
 				}
 			}
 		}

--- a/embedg-server/actions/handler/handle.go
+++ b/embedg-server/actions/handler/handle.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/merlinfuchs/discordgo"
@@ -419,6 +421,49 @@ func (m *ActionHandler) HandleActionInteraction(s *discordgo.Session, i Interact
 				if err != nil {
 					log.Error().Err(err).Msg("failed to create actions for message")
 					return err
+				}
+			}
+		case actions.ActionTypePermissionCheck:
+			perms, _ := strconv.ParseInt(action.Permissions, 10, 64)
+
+			if interaction.Member.Permissions&perms != perms {
+				responseText := "You don't have the required permissions to use this command."
+				if action.DisableDefaultResponse {
+					responseText = action.Text
+				}
+
+				i.Respond(&discordgo.InteractionResponseData{
+					Content: responseText,
+					Flags:   discordgo.MessageFlagsEphemeral,
+				})
+				return nil
+			}
+
+			responseText := "You don't have the required roles to use this command."
+			if action.DisableDefaultResponse {
+				responseText = action.Text
+			}
+
+			if len(action.RoleIDs) != 0 {
+				hasOneRole := false
+				for _, roleID := range action.RoleIDs {
+					if slices.Contains(interaction.Member.Roles, roleID) {
+						hasOneRole = true
+					} else if action.RequireAll {
+						i.Respond(&discordgo.InteractionResponseData{
+							Content: responseText,
+							Flags:   discordgo.MessageFlagsEphemeral,
+						})
+						return nil
+					}
+				}
+
+				if !hasOneRole {
+					i.Respond(&discordgo.InteractionResponseData{
+						Content: responseText,
+						Flags:   discordgo.MessageFlagsEphemeral,
+					})
+					return nil
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds a new action type which can be used to check if the user has the required permissions and roles to use the command, button, or select menu. When the user doesn't have the permissions no further actions are executed and the bot will respond with a default or custom text message.

closes #26