### PR TITLE
Handle custom bot interactions over gateway

### DIFF
--- a/embedg-app/src/components/SettingsCustomBot.tsx
+++ b/embedg-app/src/components/SettingsCustomBot.tsx
@@ -249,16 +249,14 @@ export default function SettingsCustomBot() {
                 <>
                   <CheckCircleIcon className="h-6 w-6 text-green" />
                   <div>
-                    The interaction endpoint has been configured correctly in
-                    the Discord Developer Portal
+                    The bot has handled its first interaction and is ready to go
                   </div>
                 </>
               ) : (
                 <>
                   <XCircleIcon className="h-6 w-6 text-red" />
                   <div>
-                    The interaction endpoint hasn't been configured correctly in
-                    the Discord Developer Portal
+                    The bot has handled its first interaction and is ready to go
                   </div>
                 </>
               )}
@@ -318,8 +316,8 @@ export default function SettingsCustomBot() {
               Interaction Endpoint
             </div>
             <div className="text-gray-400 font-light text-sm mb-5">
-              You need to open up your bot in the Discord Developer Portal and
-              set the Interaction Endpoint URL to this value:
+              To increase the speed and reliability of your bot, you can set the
+              Interaction Endpoint URL in the Discord Developer Portal:
             </div>
             <input
               type="url"

--- a/embedg-server/custom_bots/manager.go
+++ b/embedg-server/custom_bots/manager.go
@@ -81,8 +81,12 @@ func (m *CustomBotManager) lazyCustomBotGatewayTask() {
 				continue
 			}
 
-			// TODO: think about using gateway for custom bot interactions instead of http
-			/* bot.Session.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			bot.Session.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+				err = m.pg.Q.SetCustomBotHandledFirstInteraction(context.Background(), customBot.ID)
+				if err != nil {
+					log.Error().Err(err).Msg("Failed to set custom bot handled first interaction")
+				}
+
 				err := m.actionHandler.HandleActionInteraction(s, &handler.GatewayInteraction{
 					Session: s,
 					Inner:   i.Interaction,
@@ -90,7 +94,7 @@ func (m *CustomBotManager) lazyCustomBotGatewayTask() {
 				if err != nil {
 					log.Error().Err(err).Msg("Failed to handle action interaction from custom bot gateway")
 				}
-			}) */
+			})
 
 			bot.Session.AddHandler(func(s *discordgo.Session, i *discordgo.Disconnect) {
 				// Normally DiscordGo would handle reconnection, but it doesn't have any logic to detect a token reset and will just keep trying to reconnect with the old token


### PR DESCRIPTION
This makes the configuration of the interaction endpoint in the discord developer portal optional.