### PR TITLE
fix: default embed description value in modals

### DIFF
--- a/embedg-server/bot/components.go
+++ b/embedg-server/bot/components.go
@@ -115,7 +115,7 @@ func (b *Bot) handleEmbedComponentInteraction(s *discordgo.Session, i handler.In
 					discordgo.TextInput{
 						CustomID: "embed:description",
 						Label:    "Description",
-						Value:    currentEmbed.Title,
+						Value:    currentEmbed.Description,
 						Style:    discordgo.TextInputParagraph,
 					},
 				},


### PR DESCRIPTION
Change the default value source of the embed description from Title to Description in bot button/modal interactions